### PR TITLE
Troubleshooting undo issues with tracing the stack head

### DIFF
--- a/src/viewport/ActionQueue.hx
+++ b/src/viewport/ActionQueue.hx
@@ -24,14 +24,20 @@ class ActionQueue {
 
 	public inline function undo() {
 		if (applied.isEmpty() == false) {
+			trace("before applied head",this.applied.head);
 			this.applied.pop().undo();
+			trace("after applied head",this.applied.head);
+
 			StatusBar.inform("Reverted previous action");
 		} else {
+			trace("applied head",this.applied.head);
 			StatusBar.error("No action to undo");
 		}
 	}
 
 	public function push(a: Action) {
 		this.queue.add(a);
+		StatusBar.inform('Applied action ${a}.');
+		trace("queue head",this.queue.head);
 	}
 }


### PR DESCRIPTION
follow the terminal while doing following:
[p]lace a key
place a key
place a key, select it and then delete it
place another key leaving the vacant spot free
place the missing key
undo action one by one until no actions are left to undo.

The instant the un-deleted key needs to disappear (it's placing to be undone) the stack lowers but the key does not disappear!